### PR TITLE
Fixed kill command to work properly on linux and devcontainers

### DIFF
--- a/src/utils/port.ts
+++ b/src/utils/port.ts
@@ -19,7 +19,7 @@ export function killProcessOnPort(port: number) {
         `FOR /F "tokens=5" %a in ('netstat -ano ^| findstr :${port}') do taskkill /F /PID %a`,
       );
     } else {
-      execSync(`lsof -ti:${port} | xargs kill -9`);
+      execSync(`pids=$(lsof -ti:${port} 2>/dev/null) && [ -n "$pids" ] && echo "$pids" | xargs kill -9 || true`);
     }
   } catch (error) {
     console.error(`Failed to kill process on port ${port}:`, error);


### PR DESCRIPTION
This small fix makes browsermcp work properly on Linux, thus enabling it to work on DevContainers.

On macOS  `lsof -ti:9009` returns an empty string, so `xargs` interprets that as "no arguments", so no `kill` is run.

On Linux, however, `lsof -ti:9009` returns no output, and `xargs` still tries to run `kill -9`, causing an error.

I fixed it with a one-liner that works on both platforms and always exits with 0, so the `kill` success even if no processes are running.

This enables browsermcp to be used on devcontainers by exposing port 9009, making it suitable to work no more dev environments.