### PR TITLE
fix: prevent infinite recursion in server.close()

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -82,8 +82,10 @@ export async function createServerWithTools(options: Options): Promise<Server> {
     return { contents };
   });
 
+  // Store reference to the original close method before overriding
+  const originalClose = server.close.bind(server);
   server.close = async () => {
-    await server.close();
+    await originalClose();
     await wss.close();
     await context.close();
   };


### PR DESCRIPTION
Store reference to original close method before overriding to prevent stack overflow when closing the server.