### PR TITLE
fix: add repository metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
     "shx": "^0.3.4",
     "tsup": "^8.4.0",
     "typescript": "^5.6.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/browsermcp/mcp.git"
   }
 }


### PR DESCRIPTION
Adds the missing `repository` field to package.json for proper npm metadata.

Closes charles-openclaw/charles-microbounties#332