### PR TITLE
Add npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "MCP server for browser automation using Browser MCP",
   "author": "Browser MCP",
   "homepage": "https://browsermcp.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BrowserMCP/mcp.git"
+  },
   "bugs": "https://github.com/browsermcp/mcp/issues",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- add the missing npm `repository` metadata for the public source repository
- keep the existing `homepage` and `bugs` metadata unchanged

## Validation

```shell
node -e "const p=require('./package.json'); console.log(JSON.stringify({repository:p.repository, homepage:p.homepage, bugs:p.bugs}))"
git diff --check
```

Related verification lead: charles-openclaw/charles-microbounties#367