### PR TITLE
Add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.3",
   "description": "MCP server for browser automation using Browser MCP",
   "author": "Browser MCP",
+  "license": "Apache-2.0",
   "homepage": "https://browsermcp.io",
   "bugs": "https://github.com/browsermcp/mcp/issues",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Browser MCP",
   "homepage": "https://browsermcp.io",
   "bugs": "https://github.com/browsermcp/mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BrowserMCP/mcp.git"
+  },
   "type": "module",
   "bin": {
     "mcp-server-browsermcp": "dist/index.js"


### PR DESCRIPTION
## Summary
- add npm repository metadata pointing to this GitHub repository
- add Apache-2.0 license metadata matching the repository LICENSE file
- leave runtime code, dependencies, exports, and package version unchanged

## Verification
- Node package manifest assertion for `license` and `repository`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`